### PR TITLE
target_srs: EPSG:4258

### DIFF
--- a/services/pygeoapi_SU/local.config.yml
+++ b/services/pygeoapi_SU/local.config.yml
@@ -99,7 +99,7 @@ resources:
                   source_type: GPKG
                   source: data/SU_NL_ETRS89.gpkg
                   source_srs: EPSG:4258
-                  target_srs: EPSG:4326
+                  target_srs: EPSG:4258
                   source_capabilities:
                       paging: True
 
@@ -158,7 +158,7 @@ resources:
                   source_type: GPKG
                   source: data/SU_NL_ETRS89.gpkg
                   source_srs: EPSG:4258
-                  target_srs: EPSG:4326
+                  target_srs: EPSG:4258
                   source_capabilities:
                       paging: True
 
@@ -217,7 +217,7 @@ resources:
                   source_type: GPKG
                   source: data/SU_NL_ETRS89.gpkg
                   source_srs: EPSG:4258
-                  target_srs: EPSG:4326
+                  target_srs: EPSG:4258
                   source_capabilities:
                       paging: True
 
@@ -276,7 +276,7 @@ resources:
                   source_type: GPKG
                   source: data/SU_NL_ETRS89.gpkg
                   source_srs: EPSG:4258
-                  target_srs: EPSG:4326
+                  target_srs: EPSG:4258
                   source_capabilities:
                       paging: True
 
@@ -335,7 +335,7 @@ resources:
                   source_type: GPKG
                   source: data/SU_NL_ETRS89.gpkg
                   source_srs: EPSG:4258
-                  target_srs: EPSG:4326
+                  target_srs: EPSG:4258
                   source_capabilities:
                       paging: True
 
@@ -394,7 +394,7 @@ resources:
                   source_type: GPKG
                   source: data/SU_NL_ETRS89.gpkg
                   source_srs: EPSG:4258
-                  target_srs: EPSG:4326
+                  target_srs: EPSG:4258
                   source_capabilities:
                       paging: True
 
@@ -453,7 +453,7 @@ resources:
                   source_type: GPKG
                   source: data/SU_NL_ETRS89.gpkg
                   source_srs: EPSG:4258
-                  target_srs: EPSG:4326
+                  target_srs: EPSG:4258
                   source_capabilities:
                       paging: True
 


### PR DESCRIPTION

Dit is om te kijken of hij sneller wordt als ik de source_srs gelijk maak aan de target:
Dus target_srs: EPSG:4258 en source_srs: EPSG:4258

Hiervoor stond die taget op 4326 en de source op 4258 en duurde de gemeente 15 sec in QGIS
De WFS met dezelfde data duurde daar 3 sec.